### PR TITLE
Upgraded querydsl version to 4.1.4

### DIFF
--- a/library/build.sbt
+++ b/library/build.sbt
@@ -7,7 +7,7 @@ name := "play-querydsl"
 
 organization := "com.code-troopers.play"
 
-version := "0.1.2"
+version := "0.1.3"
 
 sbtPlugin := true
 
@@ -17,8 +17,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 /// Dependencies
 
 libraryDependencies ++= Seq(
-  "com.mysema.querydsl" % "querydsl-apt" % "3.6.2",
-  "org.hibernate.javax.persistence" % "hibernate-jpa-2.0-api" % "1.0.1.Final"
+  "com.querydsl" % "querydsl-apt" % "4.1.4"
 )
 
 pomExtra := (

--- a/library/src/main/scala/QueryDSLPlugin.scala
+++ b/library/src/main/scala/QueryDSLPlugin.scala
@@ -36,7 +36,7 @@ object QueryDSLPlugin extends AutoPlugin {
           compilers.javac(in.toSeq,
             classpath.map(_.data),
             outputDirectory,
-            Seq("-proc:only", "-processor", "com.mysema.query.apt.jpa.JPAAnnotationProcessor", "-s", outputDirectory.getAbsolutePath))(streams.log)
+            Seq("-proc:only", "-processor", "com.querydsl.apt.jpa.JPAAnnotationProcessor", "-s", outputDirectory.getAbsolutePath))(streams.log)
         } catch {
           case c: sbt.compiler.CompileFailed => streams.log.info("Compilation failed to complete, it might be because of cross dependencies")
         }
@@ -62,13 +62,13 @@ object QueryDSLPlugin extends AutoPlugin {
   import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =  Seq[Def.Setting[_]](
-    queryDSLVersion := "3.6.2",
+    queryDSLVersion := "4.1.4",
     libraryDependencies <++= (queryDSLVersion in QueryDSL)(version =>
       Seq(
         //add querydsl-apt to dependencies in QueryDSL
-        "com.mysema.querydsl" % "querydsl-apt" % version % QueryDSL.name,
+        "com.querydsl" % "querydsl-apt" % version % QueryDSL.name,
         //add querydsl-jpa to dependencies of the project
-        "com.mysema.querydsl" % "querydsl-jpa" % version
+        "com.querydsl" % "querydsl-jpa" % version
       )
     ),
     queryDSLPackage := "models",

--- a/play-querydsl-sample/app/controllers/Application.scala
+++ b/play-querydsl-sample/app/controllers/Application.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.mysema.query.jpa.impl.JPAQuery
+import com.querydsl.jpa.impl.JPAQuery
 import play.api.mvc._
 import play.db.jpa.JPA
 import models.included.QBook
@@ -11,7 +11,7 @@ object Application extends Controller {
                        val bookCount = JPA.withTransaction(new play.libs.F.Function0[Long] {
                          override def apply(): Long = {
                            new JPAQuery(JPA.em()).from(QBook.book)
-                             .where(QBook.book.title.contains("ipsum")).count()
+                             .where(QBook.book.title.contains("ipsum")).fetchCount()
                          }
                        })
                        Ok(views.html.index(bookCount))

--- a/play-querydsl-sample/project/plugins.sbt
+++ b/play-querydsl-sample/project/plugins.sbt
@@ -17,4 +17,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.0.0")
 
-addSbtPlugin("com.code-troopers.play" % "play-querydsl" % "0.1.2")
+addSbtPlugin("com.code-troopers.play" % "play-querydsl" % "0.1.3")


### PR DESCRIPTION
Querydsl has been upgraded to latest version. I also remove (at least I think) not needed hibernate dependency. 

Sample project was also updated to support new Querydsl syntax.